### PR TITLE
Document WG purpose, charter and current subgroups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
-# dev-wg
-Development Working Group
+# Development Working Group
+
+The Development Working Group, or Dev WG for short, focuses on various
+development topics surrounding OpenBao. Its purpose and governance is outlined
+in the dedicated [charter](./CHARTER.md).
+
+## Subgroups
+
+Currently, the following subgroups exist which tackle specific larger features
+or areas within the Dev WG. Contact the reponsible leads to join. Your
+contributions are much appreciated!
+
+| Subgroup               | Alias       | Lead          | GitHub                                     | Moderated ML                                |
+| ---------------------- | ----------- | ------------- | ------------------------------------------ | ------------------------------------------- |
+| Namespaces             | NS          | Alex Scheel   | [@cipherboy](https://github.com/cipherboy) | openbao-dev-wg-namespaces@lists.lfedge.org  |
+| Horizontal Scalability | Scalability | Alex Scheel   | [@cipherboy](https://github.com/cipherboy) | openbao-dev-wg-scalability@lists.lfedge.org |
+| PKCS#11                | n/a         | Alex Scheel   | [@cipherboy](https://github.com/cipherboy) | n/a                                         |
+| Supply Chain Security  | Supply      | Michael Hofer | [@karras](https://github.com/karras)       | openbao-dev-wg-supply@lists.lfedge.org      |
+
+The subgroups use dedicated and private mailing lists. A more standardized
+collaboration approach (e.g. meeting minutes or issue management) is currently
+under revision.


### PR DESCRIPTION
Simply a short PR to start documenting various gaps, and help community members get familiar and navigate the project.