### PR TITLE
Point mailing list entries from LF Edge to OpenSSF, and apply asc sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ Currently, the following subgroups exist which tackle specific larger features
 or areas within the Dev WG. Contact the reponsible leads to join. Your
 contributions are much appreciated!
 
-| Subgroup               | Alias       | Lead            | GitHub                                     | Moderated ML                                |
-| ---------------------- | ----------- | -------------   | ------------------------------------------ | ------------------------------------------- |
-| Namespaces             | NS          | Alex Scheel     | [@cipherboy](https://github.com/cipherboy) | openbao-dev-wg-namespaces@lists.lfedge.org  |
-| Horizontal Scalability | Scalability | Alex Scheel     | [@cipherboy](https://github.com/cipherboy) | openbao-dev-wg-scalability@lists.lfedge.org |
-| PKCS#11                | n/a         | Christoph Voigt | [@voigt](https://github.com/voigt)         | openbao-dev-wg-pkcs11@lists.lfedge.org      |
-| Supply Chain Security  | Supply      | Michael Hofer   | [@karras](https://github.com/karras)       | openbao-dev-wg-supply@lists.lfedge.org      |
+| Subgroup               | Alias       | Lead            | GitHub                                     | Moderated ML                                 |
+| ---------------------- | ----------- | -------------   | ------------------------------------------ | -------------------------------------------- |
+| Horizontal Scalability | Scalability | Alex Scheel     | [@cipherboy](https://github.com/cipherboy) | openbao-dev-wg-scalability@lists.openssf.org |
+| Namespaces             | NS          | Alex Scheel     | [@cipherboy](https://github.com/cipherboy) | openbao-dev-wg-namespaces@lists.openssf.org  |
+| PKCS#11                | n/a         | Christoph Voigt | [@voigt](https://github.com/voigt)         | openbao-dev-wg-pkcs11@lists.openssf.org      |
+| Supply Chain Security  | Supply      | Michael Hofer   | [@karras](https://github.com/karras)       | openbao-dev-wg-supply@lists.openssf.org      |
 
 The subgroups use dedicated and private mailing lists. A more standardized
 collaboration approach (e.g. meeting minutes or issue management) is currently


### PR DESCRIPTION
Simple PR to adjust the mailing list URLs since the project has been migrated to the OpenSSF.

Related to https://github.com/openbao/openbao/issues/1413.